### PR TITLE
Add CMake support

### DIFF
--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.26)
+project(NGen VERSION 1.0.0
+    DESCRIPTION "DSA1/RAK1 Character generator"
+    HOMEPAGE_URL "https://github.com/NewProggie/BrightEyes"
+    LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g -fno-asm")
+
+find_package(SDL2 REQUIRED)
+
+# Workaround for including either <SDL2/SDL.h> or <SDL.h>
+get_target_property(SDL2_INCLUDE_DIR SDL2::SDL2 INTERFACE_INCLUDE_DIRECTORIES)
+cmake_path(GET SDL2_INCLUDE_DIR PARENT_PATH SDL2_INCLUDE_DIR)
+
+add_executable(ngen
+    cda_code.c
+    ngen.c
+    random.c
+    powerp20.c
+    vgalib.c
+    ail_stub.c)
+
+get_filename_component(COMPILER_NAME ${CMAKE_C_COMPILER} NAME)
+set_target_properties(ngen PROPERTIES OUTPUT_NAME "ngen_${COMPILER_NAME}")
+
+target_include_directories(ngen PRIVATE ${SDL2_INCLUDE_DIR})
+target_link_libraries(ngen PUBLIC SDL2::SDL2)
+install(TARGETS ngen RUNTIME DESTINATION bin)

--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -16,7 +16,6 @@ cmake_path(GET SDL2_INCLUDE_DIR PARENT_PATH SDL2_INCLUDE_DIR)
 add_executable(ngen
     cda_code.c
     ngen.c
-    random.c
     powerp20.c
     vgalib.c
     ail_stub.c)

--- a/src/gen/ngen.c
+++ b/src/gen/ngen.c
@@ -17,7 +17,7 @@
 #include <ALLOC.H>	// farcalloc()
 #include <MATH.H>	// abs()
 #else
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <unistd.h> // lseek(), close(), read(), write()
 #endif
 

--- a/src/gen/ngen.c
+++ b/src/gen/ngen.c
@@ -17,7 +17,7 @@
 #include <ALLOC.H>	// farcalloc()
 #include <MATH.H>	// abs()
 #else
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <unistd.h> // lseek(), close(), read(), write()
 #endif
 


### PR DESCRIPTION
Adds basic CMake support for the ngen character generator. I've had to adjust the include paths to SDL2 according to their include path in the CMake configuration. Let me know if this is fine with you or if this needs special treatment for this project.