### PR TITLE
fixed msvc compatiblity, removed not needed WinMain, add some more fi…

### DIFF
--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -5,7 +5,11 @@ project(NGen VERSION 1.0.0
     LANGUAGES C)
 
 set(CMAKE_C_STANDARD 11)
+if (MSVC)
+# so far no special setting beside default for Debug/Release
+else()
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g -fno-asm")
+endif()
 
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)
@@ -17,11 +21,15 @@ get_target_property(SDL2_mixer_INCLUDE_DIR SDL2_mixer::SDL2_mixer INTERFACE_INCL
 cmake_path(GET SDL2_mixer_INCLUDE_DIR PARENT_PATH SDL2_mixer_INCLUDE_DIR)
 
 add_executable(ngen
+    cda_code.h
     cda_code.c
     ngen.c
     powerp20.c
+    vgalib.h
     vgalib.c
-    ail_stub.c)
+    ail_stub.c
+    hero.h
+)
 
 get_filename_component(COMPILER_NAME ${CMAKE_C_COMPILER} NAME)
 set_target_properties(ngen PROPERTIES OUTPUT_NAME "ngen_${COMPILER_NAME}")
@@ -32,6 +40,7 @@ if(OpenMP_C_FOUND)
 endif()
 
 target_include_directories(ngen PRIVATE ${SDL2_INCLUDE_DIR})
+target_link_libraries(ngen PUBLIC SDL2::SDL2main)
 target_link_libraries(ngen PUBLIC SDL2::SDL2)
 target_link_libraries(ngen PUBLIC SDL2_mixer::SDL2_mixer)
 install(TARGETS ngen RUNTIME DESTINATION bin)

--- a/src/gen/ngen.c
+++ b/src/gen/ngen.c
@@ -10,6 +10,14 @@
 #include <wtypes.h>
 #endif
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#define IS_UNUSED [[maybe_unused]]
+#elif !defined(_MSC_VER)
+#define IS_UNUSED __attribute__((unused))
+#else
+#define IS_UNUSED
+#endif
+
 #if defined(__BORLANDC__)
 #include <IO.H>		// lseek, _read, _close, open, write
 #include <DOS.H>
@@ -23,7 +31,12 @@
 #else
 #include <SDL.h>
 #include <SDL_mixer.h>
-#include <unistd.h> // lseek(), close(), read(), write()
+// lseek(), close(), read(), write()
+#if defined(_MSC_VER)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "ail_stub.h"
 #endif
@@ -4521,7 +4534,7 @@ static void interrupt timer_isr(void)
 	((void interrupt far (*)(void))g_timer_isr_bak)();
 }
 #else
-static Uint32 gen_timer_isr(Uint32 interval, __attribute__((unused)) void* param)
+static Uint32 gen_timer_isr(Uint32 interval, IS_UNUSED void* param)
 {
 	if (SDL_LockMutex(g_sdl_timer_mutex) == 0) {
 
@@ -7650,21 +7663,8 @@ static void intro(void)
 	g_in_intro = 0;
 }
 
-#if defined(_WIN32)
-int WinMain(__attribute__((unused)) HINSTANCE hInstance,
-		__attribute__((unused)) HINSTANCE hPrevInstance,
-		__attribute__((unused)) LPSTR lpCmdLine,
-		__attribute__((unused)) int ShowCmd)
-#else
-#define main_gen main
-int main_gen(int argc, char **argv)
-#endif
+int main(int argc, char** argv)
 {
-#if defined(_WIN32)
-	int argc;
-	LPWSTR cmdline = GetCommandLineW();
-	LPWSTR *argv = CommandLineToArgvW(cmdline, &argc);
-#endif
 	int l_level = -1;
 	char param_level;
 

--- a/src/gen/vgalib.c
+++ b/src/gen/vgalib.c
@@ -23,7 +23,7 @@
 #if !defined(__BORLANDC__)
 extern unsigned char *g_vga_memstart;
 
-static const int DEF_RATIO = 3;
+enum { DEF_RATIO = 3 };
 static int RATIO = DEF_RATIO;
 static int W_WIDTH = DEF_RATIO * O_WIDTH;
 static int W_HEIGHT = DEF_RATIO * O_HEIGHT;


### PR DESCRIPTION
-some trivial changes to make gen fully MSVC(2017,2019,2022) compatible
-removes the not needed WinMain
-adds some files to CMakeLists.txt - so there are visible in the generated VStudio solution

CMake can generate a Studio solution (if wanted) or the build can also run only on console using CMake or MSBuild

generate VS2022 Solution:

`cmake -G "Visual Studio 17 2022" -DCMAKE_PREFIX_PATH="C:\test\third_parties\SDL2-2.30.11;C:\test\third_parties\SDL2_mixer-2.8.1" ..\..\BrightEyes\src\gen`

using `-T ClangCL` additionally replaces Microsofts CL as compiler with ClangCL 
