### PR TITLE
use generic packing declartion and fixed static_assert

### DIFF
--- a/src/schick/datseg.h
+++ b/src/schick/datseg.h
@@ -561,11 +561,10 @@ struct item_flags {
 };
 #endif
 
-struct
 #if !defined(__BORLANDC__)
-__attribute__ ((packed))
+#pragma pack(1)
 #endif
-item_stats {
+struct item_stats {
 	/* https://github.com/shihan42/BrightEyesWiki/wiki/ITEMS.DAT */
 	/* structure of the entries of ITEMS.DAT */
 	int16_t gfx;
@@ -590,6 +589,9 @@ item_stats {
 	int8_t commonness;	/* which merchants do offer this item? */
 	int8_t magic;		/* 0: not magic / 1: magic */
 };
+#if !defined(__BORLANDC__)
+#pragma pack ()
+#endif
 
 STATIC_ASSERT(sizeof(struct item_stats) == 12, struct_item_stats_needs_to_be_12_bytes);
 

--- a/src/schick/hero.h
+++ b/src/schick/hero.h
@@ -1,7 +1,7 @@
 #ifndef HERO_H
 #define HERO_H
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#if __cpp_static_assert  
   #include <assert.h>
 #define STATIC_ASSERT(expr, msg) static_assert(expr, #msg)
 #else


### PR DESCRIPTION
there is no need for gcc/clang-only-packing declarations, makes MSVC happy again - #pragma pack is working everywere (also in hero.h for months)

fixed the static_assert detection to get the nice looking diagnosis output on gcc/clang/msvc